### PR TITLE
fix: resolve data race on the process exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: authenticate against the Postman API with the `X-API-Key` header and download the collection/environment in-process instead of embedding the API key in the newman command line and serialized action state (prevents leaking the key via `ps`/`/proc/<pid>/cmdline`)
 - fix: write newman reports into a unique per-execution working directory (mode 0700) and remove it on stop, instead of timestamped world-readable files in `/tmp` that could collide between concurrent runs and were never cleaned up
+- fix: resolve the data race on the newman process exit code between the process-reaping goroutine and the status/stop handlers (via `extcmd.CmdState.Wait`/`ExitCode`)
 
 ## v2.0.29
 

--- a/extpostman/action_run.go
+++ b/extpostman/action_run.go
@@ -249,7 +249,7 @@ func (f PostmanAction) Start(_ context.Context, state *PostmanState) (*action_ki
 
 	state.Pid = cmd.Process.Pid
 	go func() {
-		cmdErr := cmd.Wait()
+		cmdErr := cmdState.Wait()
 		if cmdErr != nil {
 			log.Error().Msgf("Failed to execute postman action: %s", cmdErr)
 		}
@@ -271,7 +271,7 @@ func (f PostmanAction) Status(_ context.Context, state *PostmanState) (*action_k
 	var result action_kit_api.StatusResult
 
 	// check if postman is still running
-	exitCode := cmdState.Cmd.ProcessState.ExitCode()
+	exitCode := cmdState.ExitCode()
 	if exitCode == -1 {
 		log.Info().Msgf("Postman is still running")
 
@@ -365,7 +365,7 @@ func (f PostmanAction) Stop(_ context.Context, state *PostmanState) (*action_kit
 	messages := getStdOutMessages(cmdState.GetLines(true))
 
 	// read return code and send it as Message
-	exitCode := cmdState.Cmd.ProcessState.ExitCode()
+	exitCode := cmdState.ExitCode()
 	if exitCode != 0 && exitCode != -1 {
 		messages = append(messages, action_kit_api.Message{
 			Level:   extutil.Ptr(action_kit_api.Error),

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/steadybit/discovery-kit/go/discovery_kit_commons v0.3.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
 	github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1
-	github.com/steadybit/extension-kit v1.10.5
+	github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/steadybit/discovery-kit/go/discovery_kit_commons v0.3.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
 	github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1
-	github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd
+	github.com/steadybit/extension-kit v1.10.6
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.5 h1:KSZP2vUA97QnFDhI3UAAmNg1iOv4n0ckXI/jjKrB3xc=
-github.com/steadybit/extension-kit v1.10.5/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd h1:g3NImsC9j6XyarW9zNUvpkVAPHu2X6ulrPiKe2jvhoI=
+github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd h1:g3NImsC9j6XyarW9zNUvpkVAPHu2X6ulrPiKe2jvhoI=
-github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.10.6 h1:Qz73OO7EMBpueJZjQ23wDXE0xOLBpJOz6h2ND7t6d0s=
+github.com/steadybit/extension-kit v1.10.6/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=


### PR DESCRIPTION
## Problem

`Start` reaped the process in a goroutine (`go cmd.Wait()`, which writes `cmd.ProcessState`) while `Status`/`Stop` read `cmdState.Cmd.ProcessState.ExitCode()` concurrently — a data race that `go test -race` flags and that can yield torn reads of the process result.

## Fix

Use the shared **`extcmd.CmdState.Wait()` / `ExitCode()`** API added in [extension-kit#149](https://github.com/steadybit/extension-kit/pull/149): `CmdState` owns the process result, `Wait()` is the sole reader of `cmd.ProcessState`, and `ExitCode()` returns it race-free (`-1` while running). `Start` now does `go cmdState.Wait()`; the handlers read `cmdState.ExitCode()`.

This is the same fix applied across the four extensions that share this `extcmd` pattern (extension-gatling, extension-jmeter, extension-k6, extension-postman).

## Dependency

`extension-kit` is pinned to the unreleased commit (`v1.10.6-0.20260630192502-059086860afd`) until #149 is merged and tagged; the pin should be bumped to the tagged release before merge.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...` pass.
