### PR TITLE
chore(deps): bump go to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.26.4'
+      go_version: '^1.26.5'
       build_linux_packages: false
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-postman/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
Bump Go to 1.26.5 in go.mod and CI. Also ran `go fix` and `go mod tidy`.